### PR TITLE
Use Symfony property accessor in twig extension

### DIFF
--- a/EventListener/BaseFileListener.php
+++ b/EventListener/BaseFileListener.php
@@ -88,7 +88,7 @@ class BaseFileListener implements EventSubscriberInterface
         if ($event->getData() instanceof UploadedFile) {
             $handler = $this->handlerManager->getHandler(
                 $form->getParent()->getConfig()->getDataClass(),
-                $form->getName()
+                (string) $form->getPropertyPath()
             );
 
             $datas = $handler->create($event->getData());

--- a/Extension/TwigExtension.php
+++ b/Extension/TwigExtension.php
@@ -11,6 +11,7 @@
 
 namespace Vlabs\MediaBundle\Extension;
 
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Vlabs\MediaBundle\Entity\BaseFileInterface;
 use Vlabs\MediaBundle\Handler\HandlerManager;
 use Vlabs\MediaBundle\Filter\FilterChain;
@@ -113,9 +114,8 @@ class TwigExtension extends \Twig_Extension
             return;
         }
 
-        $getter = 'get'.ucfirst($prop);
-
-        return $datas->$getter();
+        $propertyAccessor = new PropertyAccessor();
+        return $propertyAccessor->getValue($datas, $prop);
     }
 
     public function getName()

--- a/Extension/TwigExtension.php
+++ b/Extension/TwigExtension.php
@@ -11,7 +11,7 @@
 
 namespace Vlabs\MediaBundle\Extension;
 
-use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Vlabs\MediaBundle\Entity\BaseFileInterface;
 use Vlabs\MediaBundle\Handler\HandlerManager;
 use Vlabs\MediaBundle\Filter\FilterChain;
@@ -114,7 +114,7 @@ class TwigExtension extends \Twig_Extension
             return;
         }
 
-        $propertyAccessor = new PropertyAccessor();
+        $propertyAccessor = PropertyAccess::getPropertyAccessor();
         return $propertyAccessor->getValue($datas, $prop);
     }
 

--- a/Handler/AbstractHandler.php
+++ b/Handler/AbstractHandler.php
@@ -12,8 +12,8 @@
 namespace Vlabs\MediaBundle\Handler;
 
 use Symfony\Component\HttpFoundation\File\File;
-use Vlabs\MediaBundle\Entity\BaseFile;
 use Vlabs\MediaBundle\Tools\NamerInterface;
+use Vlabs\MediaBundle\Entity\BaseFileInterface;
 
 /**
  * Handle media creation and mandatory properties & service
@@ -37,7 +37,7 @@ abstract class AbstractHandler implements MediaHandlerInterface
         $baseFile->setPath($file->getPathname());
         $baseFile->setName($file->getClientOriginalName());
 
-        if ($baseFile instanceof BaseFile) {
+        if ($baseFile implements BaseFileInterface) {
             $baseFile->setCreatedAt(new \DateTime());
             $baseFile->setSize($file->getSize());
             $baseFile->setContentType($file->getMimeType());

--- a/Handler/AbstractHandler.php
+++ b/Handler/AbstractHandler.php
@@ -12,8 +12,8 @@
 namespace Vlabs\MediaBundle\Handler;
 
 use Symfony\Component\HttpFoundation\File\File;
+use Vlabs\MediaBundle\Entity\BaseFile;
 use Vlabs\MediaBundle\Tools\NamerInterface;
-use Vlabs\MediaBundle\Entity\BaseFileInterface;
 
 /**
  * Handle media creation and mandatory properties & service
@@ -36,11 +36,11 @@ abstract class AbstractHandler implements MediaHandlerInterface
 
         $baseFile->setPath($file->getPathname());
         $baseFile->setName($file->getClientOriginalName());
+        $baseFile->setContentType($file->getMimeType());
 
-        if ($baseFile implements BaseFileInterface) {
+        if ($baseFile instanceof BaseFile) {
             $baseFile->setCreatedAt(new \DateTime());
             $baseFile->setSize($file->getSize());
-            $baseFile->setContentType($file->getMimeType());
         }
 
         return $baseFile;


### PR DESCRIPTION
Uses the PropertyAccessor to correctly determine the getter method for non-trivial property access.

A camel-case private property on an entity (e.g. myProperty) should be used in a form with underscore naming convention (e.g. my_property). Determining the getter method using `'get'.ucfirst($prop)` will fail as the method `getMy_property()` will not exist on the entity.
