### PR TITLE
Now supports entity properties with underscore

### DIFF
--- a/Extension/TwigExtension.php
+++ b/Extension/TwigExtension.php
@@ -113,7 +113,13 @@ class TwigExtension extends \Twig_Extension
             return;
         }
 
-        $getter = 'get'.ucfirst($prop);
+	// construct getter from property name.
+	// if the property uses underscores each part will be camelized
+	// otherwise there's only 1 part, which will also be camelized
+	$getter = "get";
+	foreach (explode("_", $prop) as $part) {
+		$getter .= ucfirst($part);
+	}
 
         return $datas->$getter();
     }


### PR DESCRIPTION
We have decided to use lower-case + underscores for variables, including the properties of an entity. 
Example
private $front_image;

This was leading to errors, because the getter would result in getFront_image(). The getter defaults as per standard doctrine 2 (also when you use doc:gen:entities) to getFrontImage(). Therefore your function also needed to have the same behavior to prevent errors.

I hope this helps :)
